### PR TITLE
feat: 제품 API

### DIFF
--- a/src/main/java/com/back/api/product/controller/ProductController.java
+++ b/src/main/java/com/back/api/product/controller/ProductController.java
@@ -23,12 +23,18 @@ public class ProductController {
     @PatchMapping("/{id}")
     public ApiResponse<Product> update(@PathVariable Long id, @Valid @RequestBody ProductUpdateRequest request) {
         Product product = productService.update(id,request);
-        return ApiResponse.ok("%d의 제품이 수정되었습니다.".formatted(id),product);
+        return ApiResponse.ok("%d번 제품이 수정되었습니다.".formatted(id),product);
     }
 
     @GetMapping("")
     public ApiResponse<List<Product>> getAll() {
         List<Product> productList = productService.getAll();
         return ApiResponse.ok("제품 리스트 데이터입니다.",productList);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<Product> getProduct(@PathVariable Long id) {
+        Product product = productService.getProduct(id);
+        return ApiResponse.ok("%d번 제품입니다.".formatted(id),product);
     }
 }

--- a/src/main/java/com/back/api/product/controller/ProductController.java
+++ b/src/main/java/com/back/api/product/controller/ProductController.java
@@ -10,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/products")
 @RequiredArgsConstructor
@@ -22,5 +24,11 @@ public class ProductController {
     public ApiResponse<Product> update(@PathVariable Long id, @Valid @RequestBody ProductUpdateRequest request) {
         Product product = productService.update(id,request);
         return ApiResponse.ok("%d의 제품이 수정되었습니다.".formatted(id),product);
+    }
+
+    @GetMapping("")
+    public ApiResponse<List<Product>> getAll() {
+        List<Product> productList = productService.getAll();
+        return ApiResponse.ok("제품 리스트 데이터입니다.",productList);
     }
 }

--- a/src/main/java/com/back/api/product/controller/ProductController.java
+++ b/src/main/java/com/back/api/product/controller/ProductController.java
@@ -1,0 +1,26 @@
+package com.back.api.product.controller;
+
+import com.back.api.product.dto.request.ProductUpdateRequest;
+import com.back.api.product.service.ProductService;
+
+import com.back.domain.product.entity.Product;
+import com.back.global.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+@Tag(name = "1. [제품]", description = "제품 관련 API입니다.")
+public class ProductController {
+
+    private final ProductService productService;
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Product> update(@PathVariable Long id, @Valid @RequestBody ProductUpdateRequest request) {
+        Product product = productService.update(id,request);
+        return ApiResponse.ok("%d의 제품이 수정되었습니다.".formatted(id),product);
+    }
+}

--- a/src/main/java/com/back/api/product/controller/ProductController.java
+++ b/src/main/java/com/back/api/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import com.back.api.product.service.ProductService;
 
 import com.back.domain.product.entity.Product;
 import com.back.global.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,18 +21,21 @@ public class ProductController {
 
     private final ProductService productService;
 
+    @Operation(summary = "제품 수정 API", description = "제품의 설명란을 수정합니다.")
     @PatchMapping("/{id}")
     public ApiResponse<Product> update(@PathVariable Long id, @Valid @RequestBody ProductUpdateRequest request) {
         Product product = productService.update(id,request);
         return ApiResponse.ok("%d번 제품이 수정되었습니다.".formatted(id),product);
     }
 
+    @Operation(summary = "제품 다건 조회 API", description = "제품 리스트를 조회합니다..")
     @GetMapping("")
     public ApiResponse<List<Product>> getAll() {
         List<Product> productList = productService.getAll();
         return ApiResponse.ok("제품 리스트 데이터입니다.",productList);
     }
 
+    @Operation(summary = "제품 단건 조회 API", description = "제품을 조회합니다.")
     @GetMapping("/{id}")
     public ApiResponse<Product> getProduct(@PathVariable Long id) {
         Product product = productService.getProduct(id);

--- a/src/main/java/com/back/api/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/back/api/product/dto/request/ProductCreateRequest.java
@@ -1,0 +1,9 @@
+package com.back.api.product.dto.request;
+
+public record ProductCreateRequest(
+        String name,
+        String description,
+        Long price,
+        String category
+) {
+}

--- a/src/main/java/com/back/api/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/back/api/product/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.back.api.product.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "ProductUpdateRequest", description = "제품 수정 dto")
+public record ProductUpdateRequest(
+        @NotNull(message = "설명이 비어있습니다.")
+        @Schema(description = "제품 설명", example = "콜롬비아 커피 원두 입니다.")
+        String description
+
+) {
+}

--- a/src/main/java/com/back/api/product/service/ProductService.java
+++ b/src/main/java/com/back/api/product/service/ProductService.java
@@ -1,0 +1,35 @@
+package com.back.api.product.service;
+
+import com.back.api.product.dto.request.ProductCreateRequest;
+import com.back.domain.product.entity.Product;
+import com.back.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public Long count() {
+        return productRepository.count();
+    }
+
+    @Transactional
+    public void saveAll(List<ProductCreateRequest> requests) {
+        List<Product> productList = requests.stream()
+                .map(request -> Product.builder()
+                        .name(request.name())
+                        .description(request.description())
+                        .price(request.price())
+                        .category(request.category())
+                        .build())
+                .toList();
+        productRepository.saveAll(productList);
+    }
+}

--- a/src/main/java/com/back/api/product/service/ProductService.java
+++ b/src/main/java/com/back/api/product/service/ProductService.java
@@ -38,14 +38,21 @@ public class ProductService {
 
     @Transactional
     public Product update(Long id, ProductUpdateRequest request) {
-        Product product = getById(id);
+        Product product = getProduct(id);
         product.updateDescription(request);
         return product;
     }
 
-    public Product getById(Long id) {
+    public Product getProduct(Long id) {
         return productRepository.findById(id)
                 .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_PRODUCT));
     }
 
+    public List<Product> getAll() {
+        List<Product> productList = productRepository.findAll();
+        if (productList.isEmpty()) {
+            throw new ErrorException(ErrorCode.NOT_FOUND_PRODUCT);
+        }
+        return productList;
+    }
 }

--- a/src/main/java/com/back/api/product/service/ProductService.java
+++ b/src/main/java/com/back/api/product/service/ProductService.java
@@ -1,8 +1,11 @@
 package com.back.api.product.service;
 
 import com.back.api.product.dto.request.ProductCreateRequest;
+import com.back.api.product.dto.request.ProductUpdateRequest;
 import com.back.domain.product.entity.Product;
 import com.back.domain.product.repository.ProductRepository;
+import com.back.global.exception.ErrorCode;
+import com.back.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,4 +35,17 @@ public class ProductService {
                 .toList();
         productRepository.saveAll(productList);
     }
+
+    @Transactional
+    public Product update(Long id, ProductUpdateRequest request) {
+        Product product = getById(id);
+        product.updateDescription(request);
+        return product;
+    }
+
+    public Product getById(Long id) {
+        return productRepository.findById(id)
+                .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_PRODUCT));
+    }
+
 }

--- a/src/main/java/com/back/domain/product/entity/Product.java
+++ b/src/main/java/com/back/domain/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.back.domain.product.entity;
 
+import com.back.api.product.dto.request.ProductUpdateRequest;
 import com.back.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import lombok.*;
@@ -14,4 +15,8 @@ public class Product extends BaseEntity {
     private String description;
     private Long price;
     private String category;
+
+    public void updateDescription(ProductUpdateRequest request) {
+        this.description = request.description();
+    }
 }

--- a/src/main/java/com/back/domain/product/entity/Product.java
+++ b/src/main/java/com/back/domain/product/entity/Product.java
@@ -2,15 +2,13 @@ package com.back.domain.product.entity;
 
 import com.back.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @AllArgsConstructor
+@Builder
 public class Product extends BaseEntity {
     private String name;
     private String description;

--- a/src/main/java/com/back/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/back/domain/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.back.domain.product.repository;
+
+import com.back.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/back/global/config/BaseInitDataConfig.java
+++ b/src/main/java/com/back/global/config/BaseInitDataConfig.java
@@ -1,0 +1,38 @@
+package com.back.global.config;
+
+import com.back.api.product.dto.request.ProductCreateRequest;
+import com.back.api.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class BaseInitDataConfig {
+
+    private final ProductService productService;
+
+    @Bean
+    ApplicationRunner initData() {
+        return args -> {
+            work();
+        };
+    }
+
+    private void work() {
+        if (productService.count() > 0)
+            return;
+
+        ProductCreateRequest request1 = new ProductCreateRequest("Columbia Narino", null, 5000L, "커피콩");
+        ProductCreateRequest request2 = new ProductCreateRequest("Brazil Serra Do Caparao", null, 7000L, "커피콩");
+        ProductCreateRequest request3 = new ProductCreateRequest("Columbia Quindio (White Wine Extended Fermentation)", null, 10000L, "커피콩");
+        ProductCreateRequest request4 = new ProductCreateRequest("Ethiopia Sidamo", null, 4000L, "커피콩");
+        List<ProductCreateRequest> requests = List.of(request1, request2, request3, request4);
+
+        productService.saveAll(requests);
+
+    }
+}

--- a/src/main/java/com/back/global/config/JpaConfig.java
+++ b/src/main/java/com/back/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.back.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 에러");
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 에러"),
+    NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND,"제품을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/back/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/back/global/exception/GlobalExceptionHandler.java
@@ -27,14 +27,7 @@ public class GlobalExceptionHandler {
     // @Valid 유효성 검사 실패 시 발생하는 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult()
-                .getAllErrors()
-                .stream()
-                .filter(error -> error instanceof FieldError)
-                .map(error -> (FieldError) error)
-                .map(error -> error.getField() + "-" + error.getCode() + "-" + error.getDefaultMessage())
-                .sorted(Comparator.comparing(String::toString))
-                .collect(Collectors.joining("\n"));
+        String message = e.getBindingResult().getFieldError().getDefaultMessage();
         log.warn("MethodArgumentNotValidException {}", e.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(HttpStatus.BAD_REQUEST,message)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:db_dev;MODE=MySQL

--- a/src/test/java/com/back/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/back/api/product/controller/ProductControllerTest.java
@@ -1,0 +1,59 @@
+package com.back.api.product.controller;
+
+import com.back.api.product.service.ProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    @Nested
+    @DisplayName("제품 API 수정")
+    class t1 {
+        @Test
+        @DisplayName("정상 작동")
+        void success() throws Exception {
+
+            // given
+            long targetProductId = 1;
+            String description = "콜롬비아 커피 원두 입니다.";
+
+            // when
+            ResultActions result = mockMvc.perform(
+                    put("api/product/%d".formatted(targetProductId))
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(description)
+            );
+
+            // then
+            result
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("update"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(1))
+                    .andExpect(jsonPath("$.data.description").value("콜롬비아 커피 원두 입니다."))
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/com/back/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/back/api/product/controller/ProductControllerTest.java
@@ -1,6 +1,7 @@
 package com.back.api.product.controller;
 
 import com.back.api.product.dto.request.ProductUpdateRequest;
+import com.back.domain.product.repository.ProductRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +32,8 @@ class ProductControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private ProductRepository productRepository;
 
     @Nested
     @DisplayName("제품 수정 API")
@@ -107,6 +110,60 @@ class ProductControllerTest {
             resultActions
                     .andExpect(handler().handlerType(ProductController.class))
                     .andExpect(handler().methodName("update"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.message").value("제품을 찾을 수 없습니다."))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("제품 다건 조회 API")
+    class t2 {
+        @Test
+        @DisplayName("정상 작동")
+        void success() throws Exception {
+
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/products")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("getAll"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].id").value(1))
+                    .andExpect(jsonPath("$.data[0].name").value("Columbia Narino"))
+                    .andExpect(jsonPath("$.data[0].price").value(5000L))
+                    .andExpect(jsonPath("$.data[0].category").value("커피콩"))
+                    .andExpect(jsonPath("$.data[1].id").value(2))
+                    .andExpect(jsonPath("$.data[1].name").value("Brazil Serra Do Caparao"))
+                    .andExpect(jsonPath("$.data[1].price").value(7000L))
+                    .andExpect(jsonPath("$.data[1].category").value("커피콩"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("데이터가 존재안할 때")
+        void fail1() throws Exception {
+            productRepository.deleteAll();
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/products")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("getAll"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.status").value("NOT_FOUND"))
                     .andExpect(jsonPath("$.message").value("제품을 찾을 수 없습니다."))

--- a/src/test/java/com/back/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/back/api/product/controller/ProductControllerTest.java
@@ -1,6 +1,7 @@
 package com.back.api.product.controller;
 
-import com.back.api.product.service.ProductService;
+import com.back.api.product.dto.request.ProductUpdateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,9 +14,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -26,9 +28,12 @@ class ProductControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
 
     @Nested
-    @DisplayName("제품 API 수정")
+    @DisplayName("제품 수정 API")
     class t1 {
         @Test
         @DisplayName("정상 작동")
@@ -36,23 +41,75 @@ class ProductControllerTest {
 
             // given
             long targetProductId = 1;
-            String description = "콜롬비아 커피 원두 입니다.";
+            ProductUpdateRequest request = new ProductUpdateRequest("콜롬비아 커피 원두 입니다.");
 
             // when
-            ResultActions result = mockMvc.perform(
-                    put("api/product/%d".formatted(targetProductId))
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/products/%d".formatted(targetProductId))
                             .accept(MediaType.APPLICATION_JSON)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(description)
+                            .content(objectMapper.writeValueAsString(request))
             );
 
             // then
-            result
+            resultActions
                     .andExpect(handler().handlerType(ProductController.class))
                     .andExpect(handler().methodName("update"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(1))
                     .andExpect(jsonPath("$.data.description").value("콜롬비아 커피 원두 입니다."))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("valid 문제")
+        void fail1() throws Exception {
+
+            // given
+            long targetProductId = 1;
+            ProductUpdateRequest request = new ProductUpdateRequest(null);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/products/%d".formatted(targetProductId))
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("update"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                    .andExpect(jsonPath("$.message").value("설명이 비어있습니다."))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("product가 존재하지 않을 때")
+        void fail2() throws Exception {
+
+            // given
+            long targetProductId = 10000;
+            ProductUpdateRequest request = new ProductUpdateRequest("콜롬비아 커피 원두 입니다.");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/products/%d".formatted(targetProductId))
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("update"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.message").value("제품을 찾을 수 없습니다."))
                     .andDo(print());
         }
     }

--- a/src/test/java/com/back/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/back/api/product/controller/ProductControllerTest.java
@@ -95,7 +95,7 @@ class ProductControllerTest {
         void fail2() throws Exception {
 
             // given
-            long targetProductId = 10000;
+            long targetProductId = 0;
             ProductUpdateRequest request = new ProductUpdateRequest("콜롬비아 커피 원두 입니다.");
 
             // when
@@ -202,7 +202,7 @@ class ProductControllerTest {
 
         @Test
         @DisplayName("product가 존재하지 않을 때")
-        void fail2() throws Exception {
+        void fail1() throws Exception {
 
             // given
             long targetProductId = 0;

--- a/src/test/java/com/back/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/back/api/product/controller/ProductControllerTest.java
@@ -170,4 +170,58 @@ class ProductControllerTest {
                     .andDo(print());
         }
     }
+
+    @Nested
+    @DisplayName("제품 단건 조회 API")
+    class t3 {
+        @Test
+        @DisplayName("정상 작동")
+        void success() throws Exception {
+
+            // given
+            long targetProductId = 1;
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/products/%d".formatted(targetProductId))
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("getProduct"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(1))
+                    .andExpect(jsonPath("$.data.name").value("Columbia Narino"))
+                    .andExpect(jsonPath("$.data.price").value(5000L))
+                    .andExpect(jsonPath("$.data.category").value("커피콩"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("product가 존재하지 않을 때")
+        void fail2() throws Exception {
+
+            // given
+            long targetProductId = 0;
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/products/%d".formatted(targetProductId))
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(handler().handlerType(ProductController.class))
+                    .andExpect(handler().methodName("getProduct"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.message").value("제품을 찾을 수 없습니다."))
+                    .andDo(print());
+        }
+    }
 }


### PR DESCRIPTION
## 📕 작업 내용
- 제품 초기 데이터 추가
- 제품 수정 api
- 제품 단건 조회 api
- 제품 다건 조회 api
## ✏️ 작업 설명
- 9a9595ef04a1bb33924e23a377b340ca1b18c6cb : BaseInitConfig를 만들어서 초기 데이터를 넣어줍니다.
- a5c656ae31a161b19b97a31fad10d4c35f39c46d : JpaConfig 설정 누락으로 인한CreateDate, ModifyDate가 안들어가는 오류 발생하여 설정 추가하였습니다.
- 제품 수정 api : 더티 체킹을 통해 설명란을 추가할 수 있도록 설정했습니다.
- 9904a96205e5ace93714ff40c46ef2a86ee1527e : 추후에 데이터가 많아질 수도 있기 때문에 언제나 실패하도록 id를 0으로 설정했습니다.
- 성공 테스트 코드뿐만 아닌 valid, not found등 여러 실패 테스트도 구현했습니다.