### PR TITLE
feat: 고객페이지 프론트엔드 구현

### DIFF
--- a/frontend/src/app/client/page.tsx
+++ b/frontend/src/app/client/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function Client() {
+  const [products, setProducts] = useState([]);
+  const [cart, setCart] = useState<
+    { id: number; name: string; price: number; count: number }[]
+  >([]);
+  const [selectedPayment, setSelectedPayment] = useState<string | null>(null);
+
+  // localhost://8080
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  // 백엔드 서버에 저장되어 있는 상품 목록 가져오기 
+  useEffect(() => {
+    fetch("http://localhost:8080/api/products") 
+      .then(res => res.json())
+      .then(json => setProducts(json.data))
+      .catch(err => console.error(err));
+  }, []);
+
+  // 상품 "추가" 버튼 클릭 시, 장바구니에 추가
+  const handleAddToCart = (product : any) => {
+    setCart(prevCart => {
+      const existing = prevCart.find(item => item.id === product.id);
+
+      if (existing) {
+        return prevCart.map(item =>
+          item.id === product.id ? { ...item, count: item.count + 1 } : item
+        );
+      } else {
+        return [...prevCart, { id: product.id, name: product.name, price: product.price, count: 1 }];
+      }
+    });
+  };
+
+  // 상품 "삭제" 버튼 클릭 시, 장바구니에서 삭제
+  const handleRemoveFromCart = (e : React.MouseEvent<HTMLButtonElement>, productId: number) => {
+    e.preventDefault();
+
+    setCart(prevCart =>
+      prevCart
+        .map(item =>
+          item.id === productId ? { ...item, count: item.count - 1 } : item
+        )
+        .filter(item => item.count > 0)
+    );
+  };
+
+  // 장바구니에 담은 상품의 총 금액 계산
+  const totalPrice = cart.reduce((sum, item) => sum + item.price * item.count, 0);
+
+  // 3개의 결제 수단 중, 1개만 선택할 수 있도록 설정
+  const handlePaymentSelect = (method: string) => {
+    setSelectedPayment(method);
+  };
+
+  const paymentEnumMap: Record<string, string> = {
+    "신용카드": "CREDIT_CARD",
+    "계좌이체": "BANK_TRANSFER",
+    "포인트": "POINTS",
+  };
+
+  // 결제
+  const handlePay = async (e: any) => {
+    e.preventDefault();
+    const form = e.target;
+    const email = form.email;
+    const address = form.address;
+    const postcode = form.postcode;
+
+    if (cart.length === 0) {
+      alert("상품을 장바구니에 추가해주세요 :)");
+      return;
+    }
+
+    if(email.value.length === 0) {
+      alert("이메일을 입력해주세요 :)");
+      email.focus();
+      return;
+    }
+
+    if(address.value.length === 0) {
+      alert("주소를 입력해주세요 :)");
+      address.focus();
+      return;
+    }
+
+    if(postcode.value.length === 0) {
+      alert("우편번호를 입력해주세요 :)");
+      postcode.focus();
+      return;
+    }
+
+    if (!selectedPayment) {
+      alert("결제 수단을 선택해주세요 :)");
+      return;
+    }
+    
+    try {
+      // 각 상품마다 주문 생성
+      const orderResponses = await Promise.all(
+        cart.map(item =>
+          fetch("http://localhost:8080/api/order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: email.value,
+              productId: item.id,
+              quantity: item.count,
+            }),
+          }).then(res => res.json())
+        )
+      );
+
+      // 각 주문에 대해 결제 실행
+      await Promise.all(
+        orderResponses.map(order =>
+          fetch("http://localhost:8080/api/payments", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              orderId: order.data.orderId,
+              paymentMethod: paymentEnumMap[selectedPayment],
+            }),
+          })
+        )
+      );
+  
+      alert("모든 상품의 결제가 완료되었습니다 ☕️");
+    } catch (err) {
+      console.error(err);
+      alert("결제 중 오류가 발생했습니다.");
+    }
+
+  };
+
+  return (
+    <div className="container-fluid" style={{ background: '#ddd', minHeight: '100vh', padding: '24px 12px' }}>
+      <div className="row justify-content-center m-4">
+        <h1 className="text-center">Grids &amp; Circle</h1>
+      </div>
+
+      <div className="card" style={{ 
+        margin: 'auto', 
+        maxWidth: '950px', 
+        width: '90%', 
+        boxShadow: '0 6px 20px rgba(0,0,0,.19)', 
+        borderRadius: '1rem', 
+        border: 'transparent',
+        background: '#fff'
+      }}>
+        <div className="row">
+          {/* 왼쪽: 상품 리스트 */}
+          <div className="col-md-7 mt-4 d-flex flex-column align-items-start p-5 pt-3">
+            <h5 className="flex-grow-0"><b>상품 목록</b></h5>
+            <ul className="list-group">
+              {(products as Array<{
+                id: number;
+                name: string;
+                price: number;
+                description: string;
+                category: string;
+                createDate: string;
+              }>).map(product => (
+                <li className="list-group-item d-flex align-items-center mt-4" key={product.id}>
+                  <div className="col-2 me-3">
+                    <img className="img-fluid" src="https://i.imgur.com/HKOFQYa.jpeg" alt="상품"/>
+                  </div>
+                  <div className="col-5 me-6">
+                  <div className="row text-muted">{product.category}</div>
+                    <div className="row">{product.name}</div>
+                  </div>
+                  <div className="col me-2 text-end">{product.price}원</div>
+                  <div className="col text-end">
+                    <button className="btn btn-outline-dark btn-sm" onClick={() => handleAddToCart(product)}>추가</button>
+                  </div>
+                  <div>{product.description}</div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* 오른쪽: Summary */}
+          <div className="col-md-5" style={{ 
+            background: '#ddd', 
+            borderTopRightRadius: '1rem', 
+            borderBottomRightRadius: '1rem', 
+            padding: '4vh', 
+            color: '#414141' 
+          }}>
+            <div className="d-flex flex-column align-items-center">
+              <h5 className="align-self-start mb-4"><b>Summary</b></h5>
+              <div style={{ width: '100%', maxWidth: '300px' }}>
+                <h6>📌 당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</h6>
+
+                <hr style={{ marginTop: '1.25rem' }} />
+                <form onSubmit={handlePay}>
+                  <ul className="list-group mb-4">
+                    {cart.map(item => (
+                      <li key={item.id} className="list-group-item d-flex justify-content-between align-items-center">
+                        <span className="col-8 me-2">{item.name}</span>
+                        <span className="me-1" style={{ minWidth: "auto" }}>{item.count}개</span>
+                        <button
+                          className="btn btn-outline-dark btn-sm"
+                          onClick={(e) => handleRemoveFromCart(e, item.id)}
+                        >
+                          삭제
+                        </button>
+                      </li>
+                    ))}
+                    {cart.length === 0 && (
+                      <li className="list-group-item text-center">상품을 추가해주세요 ;)</li>
+                    )}
+                  </ul>
+
+                  <div className="mb-3">
+                    <label htmlFor="email" className="form-label">이메일</label>
+                    <input name="email" type="email" className="form-control mb-1" id="email" />
+                  </div>
+                  <div className="mb-3">
+                    <label htmlFor="address" className="form-label">주소</label>
+                    <input name="address" type="text" className="form-control mb-1" id="address" />
+                  </div>
+                  <div className="mb-3">
+                    <label htmlFor="postcode" className="form-label">우편번호</label>
+                    <input name="postcode" type="text" className="form-control" id="postcode" />
+                  </div>
+
+                  <div className="row pt-2 pb-2 border-top">
+                    <h5 className="col">총금액</h5>
+                    <h5 className="col text-end">{totalPrice.toLocaleString()}원</h5>
+                  </div>
+
+                  <div className="mb-2 d-flex gap-2 justify-content-between">
+                    {["신용카드", "계좌이체", "포인트"].map((method) => (
+                      <button
+                        key={method}
+                        type="button"
+                        className={`btn ${selectedPayment === method ? "btn-dark" : "btn-outline-dark"}`}
+                        onClick={() => handlePaymentSelect(method)}
+                      >
+                        {method}
+                      </button>
+                      ))}
+                  </div>
+
+                  <button className="btn btn-dark col-12" type="submit">결제하기</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📕 작업 내용
- 고객 페이지 구현

## ✏️ 작업 설명
<img width="1493" height="925" alt="스크린샷 2025-09-27 오후 4 58 50" src="https://github.com/user-attachments/assets/c111b0c2-ab35-4807-88b1-2b468ca25450" />
<img width="1661" height="925" alt="스크린샷 2025-09-27 오후 5 04 03" src="https://github.com/user-attachments/assets/4a6b857d-b8a9-42a2-b49f-3672b9021b7a" />

#### 상품목록
- mysql DB에 저장되어 있는 상품들을 가져와 보여준다. 
  - `/api/products`
- "추가" 버튼 클릭 시, summary에 선택한 상품을 추가한다.

#### Summary
- 추가된 상품의 "삭제" 버튼 클릭 시, 삭제된다. (예. 2개 -> 1개, 1개 -> summary에서 삭제)
- summary에 담긴 상품의 총금액을 계산하여 보여준다.
- 상품, 이메일, 주소, 우편번호, 결제 방법을 입력하지 않았다면, `alert` 한다.
- 이메일 규칙을 지키지 않았을 시, 사용자에게 알려준다.
   - test@test.com (이메일 규칙 지킨 예시)
   - test (이메일 규칙 지키지않은 예시)
- 입력된 정보(상품, 이메일, 주소, 우편번호, 결제 방법)를 토대로 결제를 진행하며, 결제 성공 및 실패에 대해 `alert`한다.
  - `/api/order`
  - `/api/payments`

#### 📌 개선되어야 할 부분
order 생성을 위해선 **member의 email**이 필요합니다.
따라서 결제 시, member 생성 ➡️ order 생성(`/api/order`) ➡️ 결제(`/api/payments`) 단계가 이루어져야 합니다.
그러나 member 생성 api가 없어, DB에 임의로 저장한 member(이슈 #28)의 email을 사용하여야만 결제가 이루어집니다.
정상 작동을 위해, 필히 member 생성 api를 개발해야 할 것 같습니다!