### PR TITLE
refactor: member, order entity 구조 변경 및 order 생성 api 수정

### DIFF
--- a/backend/src/main/java/com/back/api/order/controller/OrderController.java
+++ b/backend/src/main/java/com/back/api/order/controller/OrderController.java
@@ -24,6 +24,8 @@ public class OrderController {
 
     record OrderCreateReqBody(
             String email,
+            String address,
+            String postcode,
             Long productId,
             Long quantity
     ){}
@@ -32,7 +34,7 @@ public class OrderController {
     public ApiResponse<OrderDto> createOrder(
             @RequestBody @Valid OrderCreateReqBody reqBody
     ){
-        OrderDto orderDto = orderService.createOrder(reqBody.email(), reqBody.productId(), reqBody.quantity());
+        OrderDto orderDto = orderService.createOrder(reqBody.email(), reqBody.address(), reqBody.postcode(), reqBody.productId(), reqBody.quantity());
 
         return ApiResponse.ok("주문 생성 완료", orderDto
         );

--- a/backend/src/main/java/com/back/api/order/dto/OrderDto.java
+++ b/backend/src/main/java/com/back/api/order/dto/OrderDto.java
@@ -13,6 +13,8 @@ public record OrderDto(
         Long orderId,
         String memberEmail,
         LocalDateTime orderDate,
+        String orderAddress,
+        String orderPostcode,
         List<OrderProductDto> orderProducts
 ) {
     // Order 엔티티를 Dto로 변환하는 생성자
@@ -21,6 +23,8 @@ public record OrderDto(
                 order.getId(),
                 order.getMember().getEmail(),
                 order.getOrderDate(),
+                order.getAddress(),
+                order.getPostcode(),
                 orderProducts.stream()
                         .map(OrderProductDto::new)
                         .collect(Collectors.toList())

--- a/backend/src/main/java/com/back/api/order/service/OrderService.java
+++ b/backend/src/main/java/com/back/api/order/service/OrderService.java
@@ -4,6 +4,8 @@ package com.back.api.order.service;
 import com.back.api.order.dto.OrderDto;
 import com.back.api.product.service.ProductService;
 import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Role;
+import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.member.service.MemberService;
 import com.back.domain.order.entity.Order;
 import com.back.domain.order.entity.OrderProduct;
@@ -27,6 +29,7 @@ public class OrderService {
     private final OrderProductService orderProductService;
     private final MemberService memberService;
     private final ProductService productService;
+    private final MemberRepository memberRepository;
 
 
     @Transactional
@@ -43,7 +46,13 @@ public class OrderService {
     }
 
     @Transactional
-    public OrderDto createOrder(String email, long productId, long quantity) {
+    public OrderDto createOrder(String email, String address, String postcode, long productId, long quantity) {
+
+        if(!memberRepository.existsByEmail(email)) {
+            Member newMember = new Member(email, null, Role.ROLE_USER);
+            memberRepository.save(newMember);
+        }
+
         Member member = memberService.findByEmail(email);
         Product product = productService.findById(productId);
 
@@ -52,6 +61,8 @@ public class OrderService {
                 .member(member)
                 .orderDate(LocalDateTime.now())
                 .orderStatus(OrderStatus.PENDING)
+                .address(address)
+                .postcode(postcode)
                 .build();
         order = orderRepository.save(order);
         OrderProduct orderProduct = new OrderProduct(order, product, quantity);

--- a/backend/src/main/java/com/back/api/payment/dto/response/PaymentCreateResponse.java
+++ b/backend/src/main/java/com/back/api/payment/dto/response/PaymentCreateResponse.java
@@ -15,20 +15,14 @@ public record PaymentCreateResponse(
         @Schema(description = "결제 수단", example = "신용카드")
         PaymentMethod method,
         @Schema(description = "회원 이메일", example = "test@naver.com")
-        String email,
-        @Schema(description = "회원 우편번호", example = "12345")
-        String postcode,
-        @Schema(description = "회원 주소", example = "경기도 부천시")
-        String address
+        String email
 ) {
     public static PaymentCreateResponse from(Payment payment, Member member) {
         return new PaymentCreateResponse(
                 payment.getId(),
                 payment.getAmount(),
                 payment.getPaymentMethod(),
-                member.getEmail(),
-                member.getPostcode(),
-                member.getAddress()
+                member.getEmail()
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/entity/Member.java
@@ -14,8 +14,6 @@ import lombok.NoArgsConstructor;
 public class Member extends BaseEntity {
         private String email;
         private String password;
-        private String address;
-        private String postcode;
 
         @Enumerated(EnumType.STRING)
         private Role role;

--- a/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Integer> {
 
     Member findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/back/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/back/domain/order/entity/Order.java
@@ -1,17 +1,11 @@
 package com.back.domain.order.entity;
 
 import com.back.domain.member.entity.Member;
-import com.back.domain.product.entity.Product;
 import com.back.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.cglib.core.Local;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @Builder
 @Getter
@@ -29,6 +23,9 @@ public class Order extends BaseEntity {
 
     private LocalDateTime orderDate;
 
+    private String address;
+
+    private String postcode;
 
     public Order(Member member) {
         this.member = member;

--- a/backend/src/test/java/com/back/api/order/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/back/api/order/service/OrderServiceTest.java
@@ -32,13 +32,13 @@ public class OrderServiceTest {
     void createForDailyOrderProcess(OrderStatus orderStatus, LocalDateTime orderDate) {
         String email = "test@exampl.com";
         String password = "test";
-        String address = "test";
-        String postcode = "test";
         Role role = Role.ROLE_USER;
-        Member member = new Member(email, password, address, postcode, role);
+        Member member = new Member(email, password, role);
         memberRepository.save(member);
 
-        Order order = new Order(member, orderStatus, orderDate);
+        String address = "test";
+        String postcode = "test";
+        Order order = new Order(member, orderStatus, orderDate, address, postcode);
 
         orderRepository.save(order);
     }

--- a/backend/src/test/java/com/back/api/payment/controller/PaymentControllerTest.java
+++ b/backend/src/test/java/com/back/api/payment/controller/PaymentControllerTest.java
@@ -60,12 +60,12 @@ class PaymentControllerTest {
 
     @BeforeAll
     void setUp() {
-        Member member = new Member("test@naver.com", null, "경기도 부천", "55555", Role.ROLE_USER);
+        Member member = new Member("test@naver.com", null, Role.ROLE_USER);
         memberRepository.save(member);
         Product product1 = productRepository.findById(1L).orElse(null);
         Product product2 = productRepository.findById(2L).orElse(null);
-        Order order = new Order(member, OrderStatus.PENDING, LocalDateTime.now());
-        Order order1 = new Order(member, OrderStatus.CANCELED, LocalDateTime.now());
+        Order order = new Order(member, OrderStatus.PENDING, LocalDateTime.now(), "경기도 부천", "55555");
+        Order order1 = new Order(member, OrderStatus.CANCELED, LocalDateTime.now(), "경기도 부천", "55555");
         orderRepository.save(order);
         orderRepository.save(order1);
 
@@ -105,8 +105,6 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.data.method").value("CREDIT_CARD"))
                     .andExpect(jsonPath("$.data.amount").value(31000))
                     .andExpect(jsonPath("$.data.email").value("test@naver.com"))
-                    .andExpect(jsonPath("$.data.postcode").value("55555"))
-                    .andExpect(jsonPath("$.data.address").value("경기도 부천"))
                     .andDo(print());
         }
 


### PR DESCRIPTION
## 📕 작업 내용
- member, order entity 구조 변경 및 그에 따른 프로덕션코드 수정
- order 생성 api 수정
- member, order entity 구조 변경에 따른 테스트코드 수정

## ✏️ 작업 설명
#### member, order entity 구조 변경 및 프로덕션 코드 수정
- member의 `address`, `postcode` 필드 ➡️ order 필드로 변경
- entity 변경에 따른 프로덕션 코드 수정
  - `OrderDto`
  - `OrderController`
  - `OrderService`
  - `PaymentCreateResponse`

#### order 생성 api 수정
- 해당 이메일을 가진 member 없다면, member 생성

#### 테스트코드 수정
- member, order entity 구조 변경에 따라 테스트코드 수정
  - `PaymentControllerTest`
  - `OrderServiceTest`