### PR TITLE
feat: 고객 페이지 프론트엔드 구현

### DIFF
--- a/backend/src/main/java/com/back/api/order/controller/OrderController.java
+++ b/backend/src/main/java/com/back/api/order/controller/OrderController.java
@@ -24,6 +24,8 @@ public class OrderController {
 
     record OrderCreateReqBody(
             String email,
+            String address,
+            String postcode,
             Long productId,
             Long quantity
     ){}
@@ -32,7 +34,7 @@ public class OrderController {
     public ApiResponse<OrderDto> createOrder(
             @RequestBody @Valid OrderCreateReqBody reqBody
     ){
-        OrderDto orderDto = orderService.createOrder(reqBody.email(), reqBody.productId(), reqBody.quantity());
+        OrderDto orderDto = orderService.createOrder(reqBody.email(), reqBody.address(), reqBody.postcode(), reqBody.productId(), reqBody.quantity());
 
         return ApiResponse.ok("주문 생성 완료", orderDto
         );

--- a/backend/src/main/java/com/back/api/order/dto/OrderDto.java
+++ b/backend/src/main/java/com/back/api/order/dto/OrderDto.java
@@ -13,6 +13,8 @@ public record OrderDto(
         Long orderId,
         String memberEmail,
         LocalDateTime orderDate,
+        String orderAddress,
+        String orderPostcode,
         List<OrderProductDto> orderProducts
 ) {
     // Order 엔티티를 Dto로 변환하는 생성자
@@ -21,6 +23,8 @@ public record OrderDto(
                 order.getId(),
                 order.getMember().getEmail(),
                 order.getOrderDate(),
+                order.getAddress(),
+                order.getPostcode(),
                 orderProducts.stream()
                         .map(OrderProductDto::new)
                         .collect(Collectors.toList())

--- a/backend/src/main/java/com/back/api/order/service/OrderService.java
+++ b/backend/src/main/java/com/back/api/order/service/OrderService.java
@@ -4,6 +4,8 @@ package com.back.api.order.service;
 import com.back.api.order.dto.OrderDto;
 import com.back.api.product.service.ProductService;
 import com.back.domain.member.entity.Member;
+import com.back.domain.member.entity.Role;
+import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.member.service.MemberService;
 import com.back.domain.order.entity.Order;
 import com.back.domain.order.entity.OrderProduct;
@@ -27,6 +29,7 @@ public class OrderService {
     private final OrderProductService orderProductService;
     private final MemberService memberService;
     private final ProductService productService;
+    private final MemberRepository memberRepository;
 
 
     @Transactional
@@ -43,7 +46,13 @@ public class OrderService {
     }
 
     @Transactional
-    public OrderDto createOrder(String email, long productId, long quantity) {
+    public OrderDto createOrder(String email, String address, String postcode, long productId, long quantity) {
+
+        if(!memberRepository.existsByEmail(email)) {
+            Member newMember = new Member(email, null, Role.ROLE_USER);
+            memberRepository.save(newMember);
+        }
+
         Member member = memberService.findByEmail(email);
         Product product = productService.findById(productId);
 
@@ -52,6 +61,8 @@ public class OrderService {
                 .member(member)
                 .orderDate(LocalDateTime.now())
                 .orderStatus(OrderStatus.PENDING)
+                .address(address)
+                .postcode(postcode)
                 .build();
         order = orderRepository.save(order);
         OrderProduct orderProduct = new OrderProduct(order, product, quantity);

--- a/backend/src/main/java/com/back/api/payment/dto/response/PaymentCreateResponse.java
+++ b/backend/src/main/java/com/back/api/payment/dto/response/PaymentCreateResponse.java
@@ -15,20 +15,14 @@ public record PaymentCreateResponse(
         @Schema(description = "결제 수단", example = "신용카드")
         PaymentMethod method,
         @Schema(description = "회원 이메일", example = "test@naver.com")
-        String email,
-        @Schema(description = "회원 우편번호", example = "12345")
-        String postcode,
-        @Schema(description = "회원 주소", example = "경기도 부천시")
-        String address
+        String email
 ) {
     public static PaymentCreateResponse from(Payment payment, Member member) {
         return new PaymentCreateResponse(
                 payment.getId(),
                 payment.getAmount(),
                 payment.getPaymentMethod(),
-                member.getEmail(),
-                member.getPostcode(),
-                member.getAddress()
+                member.getEmail()
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/back/domain/member/entity/Member.java
@@ -14,8 +14,6 @@ import lombok.NoArgsConstructor;
 public class Member extends BaseEntity {
         private String email;
         private String password;
-        private String address;
-        private String postcode;
 
         @Enumerated(EnumType.STRING)
         private Role role;

--- a/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/back/domain/member/repository/MemberRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Integer> {
 
     Member findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/back/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/back/domain/order/entity/Order.java
@@ -1,17 +1,11 @@
 package com.back.domain.order.entity;
 
 import com.back.domain.member.entity.Member;
-import com.back.domain.product.entity.Product;
 import com.back.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.cglib.core.Local;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @Builder
 @Getter
@@ -29,6 +23,9 @@ public class Order extends BaseEntity {
 
     private LocalDateTime orderDate;
 
+    private String address;
+
+    private String postcode;
 
     public Order(Member member) {
         this.member = member;

--- a/backend/src/test/java/com/back/api/order/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/back/api/order/service/OrderServiceTest.java
@@ -32,13 +32,13 @@ public class OrderServiceTest {
     void createForDailyOrderProcess(OrderStatus orderStatus, LocalDateTime orderDate) {
         String email = "test@exampl.com";
         String password = "test";
-        String address = "test";
-        String postcode = "test";
         Role role = Role.ROLE_USER;
-        Member member = new Member(email, password, address, postcode, role);
+        Member member = new Member(email, password, role);
         memberRepository.save(member);
 
-        Order order = new Order(member, orderStatus, orderDate);
+        String address = "test";
+        String postcode = "test";
+        Order order = new Order(member, orderStatus, orderDate, address, postcode);
 
         orderRepository.save(order);
     }

--- a/backend/src/test/java/com/back/api/payment/controller/PaymentControllerTest.java
+++ b/backend/src/test/java/com/back/api/payment/controller/PaymentControllerTest.java
@@ -60,12 +60,12 @@ class PaymentControllerTest {
 
     @BeforeAll
     void setUp() {
-        Member member = new Member("test@naver.com", null, "경기도 부천", "55555", Role.ROLE_USER);
+        Member member = new Member("test@naver.com", null, Role.ROLE_USER);
         memberRepository.save(member);
         Product product1 = productRepository.findById(1L).orElse(null);
         Product product2 = productRepository.findById(2L).orElse(null);
-        Order order = new Order(member, OrderStatus.PENDING, LocalDateTime.now());
-        Order order1 = new Order(member, OrderStatus.CANCELED, LocalDateTime.now());
+        Order order = new Order(member, OrderStatus.PENDING, LocalDateTime.now(), "경기도 부천", "55555");
+        Order order1 = new Order(member, OrderStatus.CANCELED, LocalDateTime.now(), "경기도 부천", "55555");
         orderRepository.save(order);
         orderRepository.save(order1);
 
@@ -105,8 +105,6 @@ class PaymentControllerTest {
                     .andExpect(jsonPath("$.data.method").value("CREDIT_CARD"))
                     .andExpect(jsonPath("$.data.amount").value(31000))
                     .andExpect(jsonPath("$.data.email").value("test@naver.com"))
-                    .andExpect(jsonPath("$.data.postcode").value("55555"))
-                    .andExpect(jsonPath("$.data.address").value("경기도 부천"))
                     .andDo(print());
         }
 

--- a/frontend/src/app/client/page.tsx
+++ b/frontend/src/app/client/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function Client() {
+  const [products, setProducts] = useState([]);
+  const [cart, setCart] = useState<
+    { id: number; name: string; price: number; count: number }[]
+  >([]);
+  const [selectedPayment, setSelectedPayment] = useState<string | null>(null);
+
+  // 백엔드 서버에 저장되어 있는 상품 목록 가져오기 
+  useEffect(() => {
+    fetch("http://localhost:8080/api/products") 
+      .then(res => res.json())
+      .then(json => setProducts(json.data))
+      .catch(err => console.error(err));
+  }, []);
+
+  // 상품 "추가" 버튼 클릭 시, 장바구니에 추가
+  const handleAddToCart = (product : any) => {
+    setCart(prevCart => {
+      const existing = prevCart.find(item => item.id === product.id);
+
+      if (existing) {
+        return prevCart.map(item =>
+          item.id === product.id ? { ...item, count: item.count + 1 } : item
+        );
+      } else {
+        return [...prevCart, { id: product.id, name: product.name, price: product.price, count: 1 }];
+      }
+    });
+  };
+
+  // 상품 "삭제" 버튼 클릭 시, 장바구니에서 삭제
+  const handleRemoveFromCart = (e : React.MouseEvent<HTMLButtonElement>, productId: number) => {
+    e.preventDefault();
+
+    setCart(prevCart =>
+      prevCart
+        .map(item =>
+          item.id === productId ? { ...item, count: item.count - 1 } : item
+        )
+        .filter(item => item.count > 0)
+    );
+  };
+
+  // 장바구니에 담은 상품의 총 금액 계산
+  const totalPrice = cart.reduce((sum, item) => sum + item.price * item.count, 0);
+
+  // 3개의 결제 수단 중, 1개만 선택할 수 있도록 설정
+  const handlePaymentSelect = (method: string) => {
+    setSelectedPayment(method);
+  };
+
+  const paymentEnumMap: Record<string, string> = {
+    "신용카드": "CREDIT_CARD",
+    "계좌이체": "BANK_TRANSFER",
+    "포인트": "POINTS",
+  };
+
+  // 결제
+  const handlePay = async (e: any) => {
+    e.preventDefault();
+    const form = e.target;
+    const email = form.email;
+    const address = form.address;
+    const postcode = form.postcode;
+
+    if (cart.length === 0) {
+      alert("상품을 장바구니에 추가해주세요 :)");
+      return;
+    }
+
+    if(email.value.length === 0) {
+      alert("이메일을 입력해주세요 :)");
+      email.focus();
+      return;
+    }
+
+    if(address.value.length === 0) {
+      alert("주소를 입력해주세요 :)");
+      address.focus();
+      return;
+    }
+
+    if(postcode.value.length === 0) {
+      alert("우편번호를 입력해주세요 :)");
+      postcode.focus();
+      return;
+    }
+
+    if (!selectedPayment) {
+      alert("결제 수단을 선택해주세요 :)");
+      return;
+    }
+
+    try {
+      // 각 상품마다 주문 생성
+      const orderResponses = await Promise.all(
+        cart.map(item =>
+          fetch("http://localhost:8080/api/order", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: email.value,
+              address: address.value,
+              postcode: postcode.value,
+              productId: item.id,
+              quantity: item.count,
+            }),
+          }).then(res => res.json())
+        )
+      );
+
+      // 각 주문에 대해 결제 실행
+      await Promise.all(
+        orderResponses.map(order =>
+          fetch("http://localhost:8080/api/payments", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              orderId: order.data.orderId,
+              paymentMethod: paymentEnumMap[selectedPayment],
+            }),
+          })
+        )
+      );
+
+      alert("모든 상품의 결제가 완료되었습니다 ☕️");
+    } catch (err) {
+      console.error(err);
+      alert("결제 중 오류가 발생했습니다.");
+    }
+
+  };
+
+  return (
+    <div className="container-fluid" style={{ background: '#ddd', minHeight: '100vh', padding: '24px 12px' }}>
+      <div className="row justify-content-center m-4">
+        <h1 className="text-center">Grids &amp; Circle</h1>
+      </div>
+
+      <div className="card" style={{ 
+        margin: 'auto', 
+        maxWidth: '950px', 
+        width: '90%', 
+        boxShadow: '0 6px 20px rgba(0,0,0,.19)', 
+        borderRadius: '1rem', 
+        border: 'transparent',
+        background: '#fff'
+      }}>
+        <div className="row">
+          {/* 왼쪽: 상품 리스트 */}
+          <div className="col-md-7 mt-4 d-flex flex-column align-items-start p-5 pt-3">
+            <h5 className="flex-grow-0"><b>상품 목록</b></h5>
+            <ul className="list-group">
+              {(products as Array<{
+                id: number;
+                name: string;
+                price: number;
+                description: string;
+                category: string;
+                createDate: string;
+              }>).map(product => (
+                <li className="list-group-item d-flex align-items-center mt-4" key={product.id}>
+                  <div className="col-2 me-3">
+                    <img className="img-fluid" src="https://i.imgur.com/HKOFQYa.jpeg" alt="상품"/>
+                  </div>
+                  <div className="col-5 me-6">
+                  <div className="row text-muted">{product.category}</div>
+                    <div className="row">{product.name}</div>
+                  </div>
+                  <div className="col me-2 text-end">{product.price}원</div>
+                  <div className="col text-end">
+                    <button className="btn btn-outline-dark btn-sm" onClick={() => handleAddToCart(product)}>추가</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* 오른쪽: Summary */}
+          <div className="col-md-5" style={{ 
+            background: '#ddd', 
+            borderTopRightRadius: '1rem', 
+            borderBottomRightRadius: '1rem', 
+            padding: '4vh', 
+            color: '#414141' 
+          }}>
+            <div className="d-flex flex-column align-items-center">
+              <h5 className="align-self-start mb-4"><b>Summary</b></h5>
+              <div style={{ width: '100%', maxWidth: '300px' }}>
+                <h6>📌 당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</h6>
+
+                <hr style={{ marginTop: '1.25rem' }} />
+                <form onSubmit={handlePay}>
+                  <ul className="list-group mb-4">
+                    {cart.map(item => (
+                      <li key={item.id} className="list-group-item d-flex justify-content-between align-items-center">
+                        <span className="col-8 me-2">{item.name}</span>
+                        <span className="me-1" style={{ minWidth: "auto" }}>{item.count}개</span>
+                        <button
+                          className="btn btn-outline-dark btn-sm"
+                          onClick={(e) => handleRemoveFromCart(e, item.id)}
+                        >
+                          삭제
+                        </button>
+                      </li>
+                    ))}
+                    {cart.length === 0 && (
+                      <li className="list-group-item text-center">상품을 추가해주세요 ;)</li>
+                    )}
+                  </ul>
+
+                  <div className="mb-3">
+                    <label htmlFor="email" className="form-label">이메일</label>
+                    <input name="email" type="email" className="form-control mb-1" id="email" />
+                  </div>
+                  <div className="mb-3">
+                    <label htmlFor="address" className="form-label">주소</label>
+                    <input name="address" type="text" className="form-control mb-1" id="address" />
+                  </div>
+                  <div className="mb-3">
+                    <label htmlFor="postcode" className="form-label">우편번호</label>
+                    <input name="postcode" type="text" className="form-control" id="postcode" />
+                  </div>
+
+                  <div className="row pt-2 pb-2 border-top">
+                    <h5 className="col">총금액</h5>
+                    <h5 className="col text-end">{totalPrice.toLocaleString()}원</h5>
+                  </div>
+
+                  <div className="mb-2 d-flex gap-2 justify-content-between">
+                    {["신용카드", "계좌이체", "포인트"].map((method) => (
+                      <button
+                        key={method}
+                        type="button"
+                        className={`btn ${selectedPayment === method ? "btn-dark" : "btn-outline-dark"}`}
+                        onClick={() => handlePaymentSelect(method)}
+                      >
+                        {method}
+                      </button>
+                      ))}
+                  </div>
+
+                  <button className="btn btn-dark col-12" type="submit">결제하기</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -23,7 +23,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ko">
+      <head>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## 📕 작업 내용
- 고객 페이지 구현

## ✏️ 작업 설명
<img width="1493" height="925" alt="스크린샷 2025-09-27 오후 4 58 50" src="https://github.com/user-attachments/assets/c111b0c2-ab35-4807-88b1-2b468ca25450" />
<img width="1661" height="925" alt="스크린샷 2025-09-27 오후 5 04 03" src="https://github.com/user-attachments/assets/4a6b857d-b8a9-42a2-b49f-3672b9021b7a" />

#### 상품목록
- mysql DB에 저장되어 있는 상품들을 가져와 보여준다. 
  - `/api/products`
- "추가" 버튼 클릭 시, summary에 선택한 상품을 추가한다.

#### Summary
- 추가된 상품의 "삭제" 버튼 클릭 시, 삭제된다. (예. 2개 -> 1개, 1개 -> summary에서 삭제)
- summary에 담긴 상품의 총금액을 계산하여 보여준다.
- 상품, 이메일, 주소, 우편번호, 결제 방법을 입력하지 않았다면, `alert` 한다.
- 이메일 규칙을 지키지 않았을 시, 사용자에게 알려준다.
   - test@test.com (이메일 규칙 지킨 예시)
   - test (이메일 규칙 지키지않은 예시)
- 입력된 정보(상품, 이메일, 주소, 우편번호, 결제 방법)를 토대로 결제를 진행하며, 결제 성공 및 실패에 대해 `alert`한다.
  - `/api/order`
  - `/api/payments`